### PR TITLE
Fixes various build warnings

### DIFF
--- a/mod_authn_jwt.c
+++ b/mod_authn_jwt.c
@@ -137,7 +137,7 @@ static void mod_authn_jwt_patch_config(request_st * const r, plugin_data * const
     }
 }
 
-static jwt_alg_t mod_authn_jwt_process_algorithm(const char * const algstr, const uint32_t algstrlen, server * const srv);
+static jwt_alg_t mod_authn_jwt_process_algorithm(const char * const algstr, server * const srv);
 
 SETDEFAULTS_FUNC(mod_authn_jwt_set_defaults) {
     static const config_plugin_keys_t cpk[] = {
@@ -188,7 +188,7 @@ SETDEFAULTS_FUNC(mod_authn_jwt_set_defaults) {
                         cpv->v.b = NULL;
                     break;
                 case 1: /* auth.backend.jwt.algorithm */
-                    cpv->v.u = mod_authn_jwt_process_algorithm(BUF_PTR_LEN(cpv->v.b), srv);
+                    cpv->v.u = mod_authn_jwt_process_algorithm(cpv->v.b->ptr, srv);
                     cpv->vtype = T_CONFIG_LOCAL;
                     break;
                 case 2: /* auth.backend.jwt.exp-leeway */
@@ -226,7 +226,7 @@ SETDEFAULTS_FUNC(mod_authn_jwt_set_defaults) {
     return HANDLER_GO_ON;
 }
 
-static jwt_alg_t mod_authn_jwt_process_algorithm(const char * const algstr, const uint32_t algstrlen, server * const srv)
+static jwt_alg_t mod_authn_jwt_process_algorithm(const char * const algstr, server * const srv)
 {
     jwt_alg_t alg = jwt_str_alg(algstr);
 

--- a/mod_authn_jwt.c
+++ b/mod_authn_jwt.c
@@ -443,26 +443,26 @@ handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require
     for (uint32_t i = 0; NULL != claims && i < claims->used; ++i) {
         const data_unset * const du = claims->data[i];
 
-        const buffer * const key = &du->key;
+        const buffer * const claim = &du->key;
         const data_type_t type = du->type;
 
         if (type == TYPE_STRING) {
             const data_string * const ds = (const data_string *)du;
 
-            errno = jwt_valid_add_grant(jwt_valid, key->ptr, (&ds->value)->ptr);
+            errno = jwt_valid_add_grant(jwt_valid, claim->ptr, (&ds->value)->ptr);
             if (0 != errno) {
-                log_error(r->conf.errh, __FILE__, __LINE__, "Failed to add claim %s => %s: %s", key->ptr, (&ds->value)->ptr, jwt_exception_str(errno));
+                log_error(r->conf.errh, __FILE__, __LINE__, "Failed to add claim %s => %s: %s", claim->ptr, (&ds->value)->ptr, jwt_exception_str(errno));
                 goto jwt_valid_finish;
             }
         } else if (type == TYPE_INTEGER) {
             const data_integer * const di = (const data_integer *)du;
-            errno = jwt_valid_add_grant_int(jwt_valid, key->ptr, di->value);
+            errno = jwt_valid_add_grant_int(jwt_valid, claim->ptr, di->value);
             if (0 != errno) {
-                log_error(r->conf.errh, __FILE__, __LINE__, "Failed to add claim %s => %d: %s", key->ptr, di->value, jwt_exception_str(errno));
+                log_error(r->conf.errh, __FILE__, __LINE__, "Failed to add claim %s => %d: %s", claim->ptr, di->value, jwt_exception_str(errno));
                 goto jwt_valid_finish;
             }
         } else {
-            log_notice(r->conf.errh, __FILE__, __LINE__, "Unsupported type, ignoring claim", key->ptr);
+            log_notice(r->conf.errh, __FILE__, __LINE__, "Unsupported type, ignoring claim", claim->ptr);
         }
     }
 

--- a/mod_authn_jwt.c
+++ b/mod_authn_jwt.c
@@ -364,7 +364,7 @@ handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require
     jwt_t *jwt = NULL;
     size_t keylength;
     unsigned char key[10240];
-    char *keyhandle = NULL;
+    unsigned char *keyhandle = NULL;
     const buffer *keyfile = p->conf.keyfile;
 
     if (keyfile) {

--- a/mod_authn_jwt.c
+++ b/mod_authn_jwt.c
@@ -59,7 +59,7 @@ static void handler_ctx_free(handler_ctx *hctx) {
 
 static handler_t mod_auth_check_bearer(request_st *r, void *p_d, const struct http_auth_require_t *require, const struct http_auth_backend_t *backend);
 
-static handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require_t *require, const buffer *token, const char *);
+static handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require_t *require, const buffer *token, const char *pswd);
 
 /* init the plugin data */
 INIT_FUNC(mod_authn_jwt_init) {
@@ -349,9 +349,10 @@ mod_auth_check_bearer(request_st *r, void *p_d, const struct http_auth_require_t
     return rc;
 }
 
-handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require_t *require, const buffer *token, const char *)
+handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require_t *require, const buffer *token, const char *pswd)
 {
     UNUSED(require);
+    UNUSED(pswd);
 
     plugin_data *p = (plugin_data *)p_d;
 

--- a/mod_authn_jwt.c
+++ b/mod_authn_jwt.c
@@ -295,6 +295,8 @@ mod_auth_bearer_misconfigured (request_st * const r, const struct http_auth_back
 static handler_t
 mod_auth_check_bearer(request_st *r, void *p_d, const struct http_auth_require_t *require, const struct http_auth_backend_t *backend)
 {
+    UNUSED(p_d);
+
     if (backend == NULL || backend->basic == NULL)
         return mod_auth_bearer_misconfigured(r, backend);
 
@@ -349,6 +351,8 @@ mod_auth_check_bearer(request_st *r, void *p_d, const struct http_auth_require_t
 
 handler_t mod_authn_jwt_bearer(request_st *r, void *p_d, const http_auth_require_t *require, const buffer *token, const char *)
 {
+    UNUSED(require);
+
     plugin_data *p = (plugin_data *)p_d;
 
     mod_authn_jwt_patch_config(r, p);


### PR DESCRIPTION
Removes extraneous string length parameter as jwt_str_alg simply requires a null terminated string.