### PR TITLE
chore: upgrade libjwt v3.2.1 -> v3.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "benmcollins/libjwt"
-          ref: "v3.2.1"
+          ref: "v3.2.2"
           path: "libjwt"
       - name: Configure libjwt
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and build libjwt
-ADD https://github.com/benmcollins/libjwt/releases/download/v3.2.1/libjwt-3.2.1.tar.xz libjwt-3.2.1.tar.xz
-RUN tar -xJf libjwt-3.2.1.tar.xz
-RUN cmake -S libjwt-3.2.1 -B libjwt-build
+ADD https://github.com/benmcollins/libjwt/releases/download/v3.2.2/libjwt-3.2.2.tar.xz libjwt-3.2.2.tar.xz
+RUN tar -xJf libjwt-3.2.2.tar.xz
+RUN cmake -S libjwt-3.2.2 -B libjwt-build
 RUN cmake --build libjwt-build --target install
 
 # Download lighttpd

--- a/integration-test/keygen/Dockerfile
+++ b/integration-test/keygen/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:latest
 RUN apk --no-cache add \
+  bash \
   cmake \
   gcc \
   jansson-dev \
@@ -9,9 +10,9 @@ RUN apk --no-cache add \
   openssl-dev \
   pkgconfig
 
-ADD https://github.com/benmcollins/libjwt/releases/download/v3.2.1/libjwt-3.2.1.tar.xz libjwt-3.2.1.tar.xz
-RUN tar -xJf libjwt-3.2.1.tar.xz
-RUN cmake -S libjwt-3.2.1 -B libjwt-build
+ADD https://github.com/benmcollins/libjwt/releases/download/v3.2.2/libjwt-3.2.2.tar.xz libjwt-3.2.2.tar.xz
+RUN tar -xJf libjwt-3.2.2.tar.xz
+RUN cmake -S libjwt-3.2.2 -B libjwt-build
 RUN cmake --build libjwt-build --target install
 
 COPY generate-keys.sh /generate-keys.sh


### PR DESCRIPTION
Required minimum version remains unchanged.