### PR TITLE
test: explicitly run tests

### DIFF
--- a/integration-test/test.sh
+++ b/integration-test/test.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-docker compose up --build --detach
-
-docker compose exec client pytest
+docker compose run --build --rm client pytest
 code=$?
 
 docker compose down --volumes


### PR DESCRIPTION
Instead of relying on the assumed synchronicity of `... up --detach`, explicitly run pytest on the client exactly once.

I was seeing some weird CI issues where the client couldn't start because and error when starting the server. I couldn't exactly diagnose what was wrong, but after a couple re-runs it worked. This leads me to believe in some race condition and `... up --detach` followed by `... exec` seemed like a possible culprit.